### PR TITLE
yeeun-389479

### DIFF
--- a/programmers/18주차/389479/심예은.java
+++ b/programmers/18주차/389479/심예은.java
@@ -1,0 +1,34 @@
+class Solution {
+    public int solution(int[] players, int m, int k) {
+
+        int totalAdditions = 0;  // 총 서버 증설 횟수
+        int[] expireAt = new int[24]; // 해당 시간대에 만료될 서버 수
+        int activeServers = 0;  // 현재 운영 중인 서버 수
+
+        for (int hour = 0; hour < 24; hour++) {
+            // 만료된 서버 제거하는 코드
+            if (expireAt[hour] != 0) {
+                activeServers -= expireAt[hour];
+            }
+
+            // 현재 필요한 서버 개수 계산
+            int requiredServers = players[hour] / m;
+
+            if (players[hour] >= m) {
+                if (activeServers < requiredServers) {
+                    int additionalServers = requiredServers - activeServers;
+                    activeServers += additionalServers;
+                    totalAdditions += additionalServers;
+
+                    // k시간 후 서버 만료 설정
+                    if (hour + k > 23) {
+                        expireAt[hour + k - 23] = additionalServers;
+                    } else {
+                        expireAt[hour + k] = additionalServers;
+                    }
+                }
+            }
+        }
+        return totalAdditions;
+    }
+}


### PR DESCRIPTION
## 🍪 문제 번호
#이슈번호

## 🍊 문제 정의
#### input
* 0시에서 23시까지의 시간대별 게임 이용자의 수를 나타내는 1차원 정수 배열 players
* 서버 한 대로 감당할 수 있는 최대 이용자의 수를 나타내는 정수 m
* 서버 한 대가 운영 가능한 시간을 나타내는 정수 k

#### output
* 모든 게임 이용자를 감당하기 위한 최소 서버 증설 횟수를 return 

## 🍑 알고리즘 설계
1. expireAt[hour]를 적용하여, 매 시간마다 서버를 반납한다.
2. 현재 이용자 수를 기반으로 필요한 서버의 개수(requiredServers)를 계산한다.
3. 운영 중인 서버(activeServers)가 부족하면 즉시 증설한다.
4. 추가된 서버는 k시간 후 만료되므로, expireAt에 반납 시점을 기록한다.
5. 반복문 종료 후 총 서버 증설 횟수(totalAdditions) 반환한다.

## 🥝 최악 수행 시간 복잡도
* O(1)

## 🍰 특이 사항 (Optional)
테스트 케이스에서 자꾸 실패하는 바람에 다른 사람의 풀이를 찾아보았다...
* https://velog.io/@kwj0605/코딩테스트-프로그래머스-서버-증설-횟수-자바