### PR TITLE
jimin-250136

### DIFF
--- a/programmers/19주차/250136/최지민.java
+++ b/programmers/19주차/250136/최지민.java
@@ -1,0 +1,76 @@
+import java.util.*;
+
+class Node {
+    private int x, y;
+    
+    public Node(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+    
+    public int getX() {
+        return this.x;
+    }
+    
+    public int getY() {
+        return this.y;
+    }
+}
+
+class Solution {
+    public int bfs(int[][] graph, boolean[][] visited, Set<Integer> oilSet, int x, int y) {
+        Queue<Node> q = new LinkedList<>();
+        q.offer(new Node(x, y));
+        
+        int[] dx = {-1, 1, 0, 0};
+        int[] dy = {0, 0, -1, 1};
+        
+        int landCnt = 1;
+        visited[x][y] = true;
+        oilSet.add(y);
+        
+        while(!q.isEmpty()) {
+            Node node = q.poll();
+            x = node.getX();
+            y = node.getY();
+            
+            for(int i = 0; i < 4; i++) {
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+                
+                if(nx < 0 || nx >= graph.length || ny < 0 || ny >= graph[0].length) continue;
+                if(graph[nx][ny] == 0) continue;
+                
+                if(graph[nx][ny] == 1 && !visited[nx][ny]) {
+                    q.offer(new Node(nx, ny));
+                    visited[nx][ny] = true;
+                    landCnt++;
+                    
+                    oilSet.add(ny);
+                }
+            }
+        }
+        
+        return landCnt;
+    }
+    
+    public int solution(int[][] land) {
+        boolean[][] visited = new boolean[land.length][land[0].length];
+        int[] oilCnt = new int[land[0].length];
+        
+        for(int i = 0; i < land[0].length; i++) {
+            for(int j = 0; j < land.length; j++) {
+                if(land[j][i] == 1 && !visited[j][i]) {
+                    Set<Integer> oilSet = new HashSet<>();
+                    int cnt = bfs(land, visited, oilSet, j, i);
+                    
+                    for(Integer o : oilSet) {
+                        oilCnt[o] += cnt;
+                    }
+                }
+            }
+        }
+        
+        return Arrays.stream(oilCnt).max().getAsInt();
+    }
+}


### PR DESCRIPTION
## 🍪 문제 번호
#300 

## 🍊 문제 정의
#### input
land: 석유가 묻힌 땅과 석유 덩어리를 나타내는 2차원 정수 배열

#### output
이때 시추관 하나를 설치해 뽑을 수 있는 가장 많은 석유량을 반환

## 🍑 알고리즘 설계
1. 2중 for문을 사용해 석유가 있는 곳일 경우에 bfs를 사용해 덩어리의 개수를 구한다.
2. visited와 set을 전달해 방문했던 곳을 true로 처리하고, 방문했던 열을 set에 담도록 한다.
3. bfs를 사용하여 덩어리의 개수를 구한다.
4. 반환된 덩어리의 개수를 set에 담긴 열의 수를 인덱스로 사용하여 배열에 누적시킨다.
5. 순회가 끝난 후에 배열에 저장된 수 중 가장 큰 수를 반환한다.

## 🥝 최악 수행 시간 복잡도
O(N^2)

## 🍰 특이 사항 (Optional)
- [동빈나 bfs 코드 참고](https://github.com/ndb796/python-for-coding-test/blob/master/5/11.java)