### PR TITLE
jimin-92342

### DIFF
--- a/programmers/20주차/92342/최지민.java
+++ b/programmers/20주차/92342/최지민.java
@@ -1,0 +1,53 @@
+import java.util.*;
+
+class Solution {
+    int result = -1;
+    int[] maxScore = {-1};
+    
+    private void dfs(int idx, int arrowLeft, int[] ryan, int[] info) {
+        if(idx == 11 || arrowLeft == 0) {
+            int[] copyArr = Arrays.copyOf(ryan, 11);
+            if(arrowLeft > 0) copyArr[10] += arrowLeft;
+            
+            int ryanScore = 0, apeachScore = 0;
+            
+            for(int i = 0; i < 11; i++) {
+                if(copyArr[i] == 0 && info[i] == 0) continue;
+                
+                if(copyArr[i] > info[i]) ryanScore += (10 - i);
+                else apeachScore += (10 - i);
+            }
+            
+            int scoreGap = ryanScore - apeachScore;
+            if(scoreGap <= 0) return;
+            
+            if(result < scoreGap) {
+                result = scoreGap;
+                maxScore = copyArr;
+            } else if(result == scoreGap) {
+                for(int i = 10; i > -1; i--) {
+                    if(copyArr[i] > maxScore[i]) {
+                        maxScore = copyArr;
+                        break;
+                    } else if(maxScore[i] > copyArr[i]) break;
+                }
+            }
+            
+            return;
+        }
+        
+        if(arrowLeft > info[idx]) {
+            ryan[idx] = info[idx] + 1;
+            dfs(idx + 1, arrowLeft - ryan[idx], ryan, info);
+            ryan[idx] = 0;
+        }
+        
+        dfs(idx + 1, arrowLeft, ryan, info);
+    }
+    
+    public int[] solution(int n, int[] info) {
+        dfs(0, n, new int[11], info);
+        
+        return maxScore;
+    }
+}


### PR DESCRIPTION
## 🍪 문제 번호
#313 

## 🍊 문제 정의
#### input
n: 화살의 개수를 담은 자연수
info: 어피치가 맞힌 과녁 점수의 개수를 10점부터 0점까지 순서대로 담은 정수 배열

#### output
라이언이 가장 큰 점수 차이로 우승하기 위해 n발의 화살을 어떤 과녁 점수에 맞혀야 하는지를 10점부터 0점까지 순서대로 정수 배열에 담아 반환

## 🍑 알고리즘 설계
**dfs** + **백트래킹** 풀이
1. 남은 화살의 개수가 사용해야 하는 화살의 개수보다 클 경우:
    1-1. 사용한 화살의 개수 저장 후, dfs 재귀로 진행
    1-2. 백트래킹으로 화살의 개수 복원
2. 화살을 사용하지 않고 넘어가는 경우는 아무런 처리 없이 재귀 진행
3. 인덱스가 끝까지 진행 됐거나, 화살이 남지 않은 경우를 종료 조건으로 설정
    3-1. 배열을 바꿨을 경우에 값이 같이 변하지 않도록 카피한 배열을 생성
    3-2. 라이언과 어피치의 점수를 구해 어피치가 점수가 더 크거나 같으면 그대로 return
    3-3. 현재 저장된 최대값보다 현재 값이 더 크다면 값과 배열 모두 갱신
    3-4. 만약 같다면, 작은 점수를 더 많이 쏜 배열이 들어가야 하므로 비교 후 배열 갱신

## 🥝 최악 수행 시간 복잡도
O(2^N)

## 🍰 특이 사항 (Optional)
1. dfs와 백트래킹을 같이 쓴다는 이 아이디어를 생각해내기가 어려워 gpt 참고하여 풀이,,,
뭔가 하나하나 다 따져봐야 한다는 건 알았는데, dfs를 조합으로 사용해 풀이하는 문제를 많이 안 풀어봐서 그런지 풀이법이 쉽게 생각나지 않고,,,, 답을 봐도 잘 몰랐음

- gpt한테 물어본 dfs를 떠올려야 할 경우
✅ DFS로 탐색할 수 있다고 떠올리는 키워드
"경우의 수를 다 봐야 해!"
"각 선택마다 다음 선택으로 이어질 수 있어!"
"결정 하나에 따라 다음 단계가 달라져!"
"끝까지 갔을 때 평가해!"

여기서 탐색 중에 다시 되돌아갈 경우 원래대로 돌려놔야 정확한 탐색을 할 수 있기 때문에 -> **백트래킹** 같이 사용