### PR TITLE
jimin-148652

### DIFF
--- a/programmers/23주차/148652/최지민.java
+++ b/programmers/23주차/148652/최지민.java
@@ -1,0 +1,27 @@
+class Solution {
+    private long count(int n, long k) {
+        if(n == 0) {
+            return 1;
+        }
+        
+        long blockCnt = (long) Math.pow(5, n - 1);
+        long oneCnt = (long) Math.pow(4, n - 1);
+        
+        long blockNum = k / blockCnt;
+        if(k % blockCnt == 0) blockNum--;
+        
+        long innerIdx = (k % blockCnt == 0) ? blockCnt : k % blockCnt;
+        
+        if(blockNum == 2) {
+            return oneCnt * blockNum;
+        } else if(blockNum < 2) {
+            return oneCnt * blockNum + count(n - 1, innerIdx);
+        } else {
+            return oneCnt * (blockNum - 1) + count(n - 1, innerIdx);
+        }
+    }
+    
+    public int solution(int n, long l, long r) {
+        return (int)(count(n, r) - count(n, l - 1));
+    }
+}


### PR DESCRIPTION
## 🍪 문제 번호
#358 

## 🍊 문제 정의
#### input
n과 1의 개수가 몇 개인지 알고 싶은 구간을 나타내는 l, r

#### output
그 구간 내의 1의 개수를 반환

## 🍑 알고리즘 설계
1. 재귀함수를 사용해 처음부터 r까지의 1의 개수, l까지의 개수를 구해 빼준다.
> 재귀함수
종료 조건: n == 0
1. 5^(n-1)을 구해 구역마다 비트의 개수가 몇 개 존재하는지 구한다.
2. 4^(n-1)을 구해 구역마다 1의 개수가 몇 개 존재하는지 구한다.
3. 현재 k에 블록안의 비트 개수를 나눠 k가 몇 번째 블록에 존재하는지 구한다.
4. 만약 blockNum이 2라면 중간 블록에 존재하는 것이므로 모두 0이기 때문에 재귀 없이 값을 리턴한다.
5. 2 이하라면, 1의 개수 + 재귀를 통해 k를 안쪽 인덱스 기준의 번호(innerIdx)로 바꿔준 후 재귀를 호출한다.
6. 그 외의 경우도 똑같이 수행한다.
7. 종료 후 반환되는 값을 빼 반환한다.

## 🥝 최악 수행 시간 복잡도
O(N)

## 🍰 특이 사항 (Optional)
- [해당 코드 참고](https://keepgoing0328.tistory.com/137)