### PR TITLE
dayeon-169198

### DIFF
--- a/programmers/29주차/169198/장다연.java
+++ b/programmers/29주차/169198/장다연.java
@@ -1,0 +1,41 @@
+import java.util.*;
+
+class Solution {
+    private enum Direct {
+        UP, DOWN, LEFT, RIGHT;
+    }
+    public int[] solution(int m, int n, int startX, int startY, int[][] balls) {
+        int[] answer = new int[balls.length];
+        Arrays.fill(answer, Integer.MAX_VALUE);
+        for(int i=0; i<balls.length; i++){
+            int[] b = balls[i];
+            //상 -> x가 같고 startY가 더 작으면 안됨
+            if(!(startX == b[0] && startY < b[1])){
+                answer[i] = Math.min(answer[i], calculateDirect(Direct.UP, startX, startY, b[0], b[1], m, n));
+            }
+            //하 -> x가 같고 startY가 더 크면 안됨
+            if(!(startX == b[0] && startY > b[1])){
+                answer[i] = Math.min(answer[i], calculateDirect(Direct.DOWN, startX, startY, b[0], b[1], m, n));
+            }
+            //좌 -> y가 같고 startX가 더 크면 안됨
+            if(!(startY == b[1] && startX > b[0])){
+                answer[i] = Math.min(answer[i], calculateDirect(Direct.LEFT, startX, startY, b[0], b[1], m, n));
+            }
+            //우 -> y가 같고 startX가 더 작으면 안됨
+            if(!(startY == b[1] && startX < b[0])){
+                answer[i] = Math.min(answer[i], calculateDirect(Direct.RIGHT, startX, startY, b[0], b[1], m, n));
+            }
+        }
+        return answer;
+    }
+    private int calculateDirect(Direct d, int sX, int sY, int eX, int eY, int m, int n){
+        int answer = 0;
+        switch(d){
+            case UP -> answer = (int) Math.pow(eX-sX,2) + (int) Math.pow(n+(n-sY)-eY,2);
+            case DOWN -> answer = (int) Math.pow(eX-sX,2) + (int) Math.pow(sY+eY,2);
+            case LEFT -> answer = (int) Math.pow(eY-sY,2) + (int) Math.pow(sX+eX,2);
+            case RIGHT -> answer = (int) Math.pow(eY-sY,2) + (int) Math.pow(m+(m-sX)-eX,2);
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🍪 문제 번호
#443

## 🍊 문제 정의
#### input
당구대의 가로 길이 m, 세로 길이 n과 머쓱이가 쳐야 하는 공이 놓인 위치 좌표를 나타내는 두 정수 startX, startY, 그리고 매 회마다 목표로 해야하는 공들의 위치 좌표를 나타내는 정수 쌍들이 들어있는 2차원 정수배열 balls

#### output
"원쿠션" 연습을 위해 머쓱이가 공을 적어도 벽에 한 번은 맞춘 후 목표 공에 맞힌다고 할 때, 각 회마다 머쓱이가 친 공이 굴러간 거리의 최솟값의 제곱을 배열에 담아 return

## 🍑 알고리즘 설계
![image](https://github.com/user-attachments/assets/43494576-0b38-4fed-af8b-a9817b0e468b)
위 그림처럼 상하좌우의 벽에 부딪혔을 때 모두 구해 Min 값을 리턴함
-> 이 때 예외처리로 벽에 부딪히기 전에 공이 먼저 부딪힐 경우는 제외함

## 🥝 최악 수행 시간 복잡도
O(n)

## 🍰 특이 사항 (Optional)
https://velog.io/@cheezeomelette/%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9E%98%EB%A8%B8%EC%8A%A4-%EB%8B%B9%EA%B5%AC-%EC%97%B0%EC%8A%B5