### PR TITLE
jimin-42898

### DIFF
--- a/programmers/33주차/42898/최지민.java
+++ b/programmers/33주차/42898/최지민.java
@@ -1,0 +1,29 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int m, int n, int[][] puddles) {
+        int[][] graph = new int[m + 2][n + 2];
+        graph[1][1] = 1;
+        
+        for(int i = 1; i <= m; i++) {
+            for(int j = 1; j <= n; j++) {
+                // i, j 까지의 최단 경로 개수
+                if(isPuddle(i, j, puddles) || (i == 1 && j == 1)) continue;
+                
+                graph[i][j] = (graph[i - 1][j] + graph[i][j - 1]) % 1_000_000_007;
+            }
+        }
+        
+        return graph[m][n];
+    }
+    
+    private boolean isPuddle(int x, int y, int[][] puddles) {
+        for(int[] p : puddles) {
+            if(p[0] == x && p[1] == y) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+}


### PR DESCRIPTION
## 🍪 문제 번호
#477 

## 🍊 문제 정의
#### input
m, n: 격자의 크기
puddles: 물이 잠긴 지역의 좌표를 담은 2차원 배열

#### output
오른쪽과 아래쪽으로만 움직여 집에서 학교까지 갈 수 있는 최단경로의 개수를 1,000,000,007로 나눈 나머지를 반환

## 🍑 알고리즘 설계
**DP**
1. 최단 경로의 개수를 저장한 graph를 생성하는데, 범위 오류 방지를 위해 패딩값을 더해 생성한다.
2. 1, 1부터 2중 for문을 순회하며 웅덩이를 피해 위쪽과 왼쪽의 누적값을 더해 갱신한다.
3. for문이 끝난 후, [n, m] 자리의 최단경로의 개수를 반환한다.

## 🥝 최악 수행 시간 복잡도
O(N^2)

## 🍰 특이 사항 (Optional)
- DP인지 몰랐음,,
😕 왜 처음엔 DP가 안 떠올랐을까?
"최단 거리"라는 키워드 → BFS를 떠올리기 쉬움
그러나 이 문제는 **거리 자체가 아니라 "경로 수"**를 구하는 것 → DP가 적합
BFS로 경로 수를 구하려면 visited 체크를 잘못하면 오답이 될 수 있어 구현이 번거롭고 시간도 오래 걸립니다.

https://chatgpt.com/share/687203f6-0470-8012-81fb-91c3689eee47