### PR TITLE
dayeon-17678

### DIFF
--- a/programmers/37주차/17678/장다연.java
+++ b/programmers/37주차/17678/장다연.java
@@ -1,0 +1,68 @@
+import java.util.*;
+class Solution {
+    public String solution(int n, int t, int m, String[] timetable) {
+        
+        Map<Integer, Integer> tt = new HashMap<>(); //시간 대별 대기 크루 수
+        
+        for(String time : timetable){
+            int formattedTime = stringToInt(time);
+            tt.put(formattedTime, tt.getOrDefault(formattedTime,0)+1);
+        }
+        // System.out.println(tt);
+        
+        //큐에 시간 추가
+        PriorityQueue<Integer> ttKeys = new PriorityQueue<>();
+        for(int key : tt.keySet()){
+            ttKeys.add(key);
+        }
+        
+        //콘의 제일 늦은 도착 시간 찾기
+        int startTime = stringToInt("09:00");
+        int sleepTime = stringToInt("23:59");
+        int answer = -1;
+        for(int i=startTime; i<startTime+(n*t) && i<=sleepTime; i+=t){
+            int nowEmptySpaces = m;        
+            while(!ttKeys.isEmpty() && ttKeys.peek() <= i && nowEmptySpaces > 0){
+                int nowTime = ttKeys.peek(); //현재 크루 시간대
+                int nowWaits = tt.get(nowTime);
+                if(nowEmptySpaces - nowWaits >= 0){ //같은 시간에 들어온 크루 모두 탈 수 있을 경우
+                    nowEmptySpaces -= nowWaits;
+                    // tt.remove(nowTime); //데이터 남아 있어도 상관 X
+                    ttKeys.poll();
+                    
+                } else{ //같은 시간에 들어온 크루 중간에 잘라야할 경우
+                    tt.put(nowTime, nowWaits - nowEmptySpaces);
+                    nowEmptySpaces = 0;
+                }
+                /*
+                원래 if - else 각각 answer 값 갱신했는데 그러면 
+                
+                100, 60, 1, ["09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00"]
+                -> 기댓값 : "08:59"
+                -> 끝까지 answer 갱신이 안되고 -1로 남는 문제 발생
+                
+                1, 10, 2, ["08:59", "09:00", "09:00"] -> 기댓값 : "08:59"
+                -> 09:00으로 리턴하는 문제
+                
+                가 발생한다. 그렇기 때문에 answer 갱신은 크루보다 항상 1분 일찍 도착한 값을 저장해서 무조건 탈 수 있게 하는데, 만약 자리가 남아 있어 더 늦게 탈 수 있으면 while문 밖의 if절을 통해 버스오는 시간인 i로 갱신하게 해야 한다.
+                */
+                
+                answer = nowTime-1; //19~23번 테케 위해 필요
+            }
+            if(nowEmptySpaces > 0) answer = i;
+            // System.out.println(intToString(i)+"->"+intToString(answer));
+        }
+        return intToString(answer);
+    }
+    private int stringToInt(String t){
+        String[] time = t.split(":");
+        int hour = Integer.parseInt(time[0]);
+        int min = Integer.parseInt(time[1]);
+        return hour * 60 + min;
+    }
+    private String intToString(int t){
+        String hour = (t / 60) < 10 ? "0"+(t / 60) : ""+(t / 60);
+        String min = (t % 60) < 10 ? "0"+(t % 60) : ""+(t % 60);
+        return hour + ":" + min;
+    }
+}


### PR DESCRIPTION
## 🍪 문제 번호
#523

## 🍊 문제 정의
#### input
셔틀 운행 횟수 n, 셔틀 운행 간격 t, 한 셔틀에 탈 수 있는 최대 크루 수 m, 크루가 대기열에 도착하는 시각을 모은 배열 timetable
#### output
콘이 무사히 셔틀을 타고 사무실로 갈 수 있는 제일 늦은 도착 시각

## 🍑 알고리즘 설계
빡구현 문제

시간대별로 들어온 크루를 map으로 저장하고, 정렬은 pq를 활용했다.

pq를 순회하면서, 버스가 들어올 때마다 몇 명의 크루가 탈지 pq에서 poll하고, 그 때마다 콘이 만약에 이번 버스를 탄다고 하면 몇 시에 나와야 하는지 저장했다. 만약 이 때 자리 여유가 있어서 버스 오는 시간에 딱 맞추어 도착해도 된다고 하면 이 때는 i를 저장하도록 했다.

이렇게 마지막 버스까지 확인하고, 버스가 들어올 때마다 갱신되었던 answer값을 그대로 리턴해서 문제를 해결하였다.

## 🥝 최악 수행 시간 복잡도
O(N^2)

## 🍰 특이 사항 (Optional)
반례를 만듦
/*
                원래 if - else 각각 answer 값 갱신했는데 그러면 
                
                100, 60, 1, ["09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00", "09:00"]
                -> 기댓값 : "08:59"
                -> 끝까지 answer 갱신이 안되고 -1로 남는 문제 발생
                
                1, 10, 2, ["08:59", "09:00", "09:00"] -> 기댓값 : "08:59"
                -> 09:00으로 리턴하는 문제
                
                가 발생한다. 그렇기 때문에 answer 갱신은 크루보다 항상 1분 일찍 도착한 값을 저장해서 무조건 탈 수 있게 하는데, 만약 자리가 남아 있어 더 늦게 탈 수 있으면 while문 밖의 if절을 통해 버스오는 시간인 i로 갱신하게 해야 한다.
                */
