### PR TITLE
dayeon-42892

### DIFF
--- a/programmers/40주차/42892/장다연.java
+++ b/programmers/40주차/42892/장다연.java
@@ -1,0 +1,108 @@
+import java.util.*;
+
+class Solution {
+    private List<Node> nodeInfoList;
+    private List<Integer> preorderList = new ArrayList<>();
+    private List<Integer> postorderList = new ArrayList<>();
+
+    private class Node {
+        int num, x, y;
+        Node left, right;
+        int min, max; // 허용 x 범위 (exclusive 비교 사용)
+        public Node(int num, int x, int y) {
+            this.num = num; this.x = x; this.y = y;
+            left = right = null;
+            // 기본값은 전체 범위
+            this.min = Integer.MIN_VALUE;
+            this.max = Integer.MAX_VALUE;
+        }
+        @Override
+        public String toString() {
+            return num + " x=" + x + " [" + min + "," + max + "] L:" + (left!=null?left.num:"-") + " R:" + (right!=null?right.num:"-");
+        }
+    }
+
+    public int[][] solution(int[][] nodeinfo) {
+        int n = nodeinfo.length;
+        int[][] answer = new int[2][n];
+
+        // 노드 생성
+        nodeInfoList = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            nodeInfoList.add(new Node(i + 1, nodeinfo[i][0], nodeinfo[i][1]));
+        }
+
+        // y 내림차순, x 오름차순 정렬 (루트부터, 같은 레벨은 좌->우)
+        Collections.sort(nodeInfoList, (a, b) -> {
+            if (a.y == b.y) return a.x - b.x;
+            return b.y - a.y;
+        });
+
+        // 레벨 기반 연결: 첫 노드는 루트
+        List<Node> parent = new ArrayList<>();
+        Node root = nodeInfoList.get(0);
+        root.min = Integer.MIN_VALUE;
+        root.max = Integer.MAX_VALUE;
+        parent.add(root);
+
+        // i 를 수동으로 증가시키며 같은 y값(=같은 레벨)인 노드들 모으기
+        for (int i = 1; i < nodeInfoList.size();) {
+            List<Node> child = new ArrayList<>();
+            int childY = nodeInfoList.get(i).y;
+            while (i < nodeInfoList.size() && nodeInfoList.get(i).y == childY) {
+                child.add(nodeInfoList.get(i));
+                i++;
+            }
+
+            int cIdx = 0; // child 리스트에서 소비할 인덱스
+            for (Node p : parent) {
+                // 왼쪽 자식 후보
+                if (cIdx < child.size()) {
+                    Node c = child.get(cIdx);
+                    if (p.min < c.x && c.x < p.x) {
+                        p.left = c;
+                        c.min = p.min;
+                        c.max = p.x;
+                        cIdx++;
+                    }
+                }
+                // 오른쪽 자식 후보
+                if (cIdx < child.size()) {
+                    Node c = child.get(cIdx);
+                    if (p.x < c.x && c.x < p.max) {
+                        p.right = c;
+                        c.min = p.x;
+                        c.max = p.max;
+                        cIdx++;
+                    }
+                }
+            }
+
+            // 다음 레벨의 부모는 지금의 child 들(좌->우 순서)
+            parent = child;
+        }
+
+        // 순회 결과 채우기
+        preorder(root);
+        postorder(root);
+        for (int i = 0; i < n; i++) {
+            answer[0][i] = preorderList.get(i);
+            answer[1][i] = postorderList.get(i);
+        }
+        return answer;
+    }
+
+    private void preorder(Node now) {
+        if (now == null) return;
+        preorderList.add(now.num);
+        preorder(now.left);
+        preorder(now.right);
+    }
+
+    private void postorder(Node now) {
+        if (now == null) return;
+        postorder(now.left);
+        postorder(now.right);
+        postorderList.add(now.num);
+    }
+}


### PR DESCRIPTION
## 🍪 문제 번호
#547 

## 🍊 문제 정의
#### input
곤경에 빠진 카카오 프렌즈를 위해 이진트리를 구성하는 노드들의 좌표가 담긴 배열 nodeinfo
#### output
노드들로 구성된 이진트리를 전위 순회, 후위 순회한 결과를 2차원 배열에 순서대로 담아 return

## 🍑 알고리즘 설계
1. 이진탐색 트리 구성
- 같은 레벨끼리 어느 부모의 왼쪽 혹은 오른쪽에 연결할지 결정 후 연결
- 이 때 유의할 점은 1. 왼쪽 자식 트리는 나보다 작아야 하고, 오른쪽 자식 트리는 나보다 무조건 커야함. 2. 각 노드별로 자기를 포함한 부모까지의 min과,max값을 저장해서 자식을 추가할 수 있는 범위 내여야 함
- 2번의 경우 예시로 설명하자면

```
          (5)
        /     \
     (3)       (8)
    /   \
 (2)     (4)

```

부모 (8)의 범위: [min, max] = [5, +∞]

(6) → 5 < 6 < 8 → 왼쪽 자식

(9) → 8 < 9 < +∞ → 오른쪽 자식

이렇게 되는 거!
- 그 다음에 전위탐색, 후위탐색은 각각 방문을 맨 처음, 맨 마지막으로 해서 해결함

## 🥝 최악 수행 시간 복잡도
O(N^2)