### PR TITLE
dayeon-150365

### DIFF
--- a/programmers/40주차/150365/장다연.java
+++ b/programmers/40주차/150365/장다연.java
@@ -1,0 +1,42 @@
+import java.util.*;
+
+class Solution {
+    private int[] dx = {1, 0, 0, -1};
+    private int[] dy = {0, -1, 1, 0};
+    private char[] dirct = {'d', 'l', 'r', 'u'};
+    private String result = null;
+    public String solution(int n, int m, int x, int y, int r, int c, int k) {
+        int[] start = {x-1,y-1};
+        int[] end = {r-1,c-1};
+        bfs(k, n, m, start, end, new char[k]);
+        return result == null? "impossible" : result;
+    }
+    private void bfs(int k, int n, int m, int[] now, int[] end, char[] rst){
+        if(result != null) return;
+        
+        int dist = Math.abs(now[0] - end[0]) + Math.abs(now[1] - end[1]);
+        if(dist > k || (k - dist) % 2 != 0) return;
+        
+        if(k==0 && (now[0] == end[0] && now[1] == end[1])) {
+            // System.out.println("됨"+new String(rst));
+            result = new String(rst);
+            return;
+        } else if(k==0) {
+            // System.out.println("안됨"+new String(rst));
+            return;
+        }
+        
+        for(int i=0; i<4; i++){
+            int[] next = {now[0]+dx[i], now[1]+dy[i]};
+            
+            if(!canMove(n,m,next)) continue;
+            rst[rst.length-k] = dirct[i];
+            bfs(k-1, n, m, next, end, rst);
+        }
+    }
+    
+    private boolean canMove(int n, int m, int[] next){
+        if(next[0] < 0 || next[0] >= n || next[1] < 0 || next[1] >= m) return false;
+        return true;
+    }
+}


### PR DESCRIPTION
## 🍪 문제 번호
#547

## 🍊 문제 정의
#### input
격자의 크기를 뜻하는 정수 n, m, 출발 위치를 뜻하는 정수 x, y, 탈출 지점을 뜻하는 정수 r, c, 탈출까지 이동해야 하는 거리를 뜻하는 정수 k
#### output
미로를 탈출하기 위한 경로

## 🍑 알고리즘 설계
bfs로만 해결을 하게 되면, O(4^2500) 이므로 시간 초과가 발생하는 것이었다. 방문을 2번 이상이 가능하기 때문에, 이런 시간복잡도가 되는 것이고.

그렇기 때문에 백트래킹이 필요하다.
1. 방문 가능한 케이스가 나오면 더 이상 탐색하지 않기
2. 남은 k로 목적지까지 이동할 수 없는 경우 탐색하지 않기

이 두가지를 코드에 넣어 조건에 대한 가지치기가 필요했다. 2번은 거리를 계산하는 맨헤튼 거리 공식(abs(도착x-현재x) + abs(도착y-현재y) <= 남은 이동 거리 횟수) 을 이용했다.

## 🥝 최악 수행 시간 복잡도
O(n∗m∗k) -> 이동 불가능할 경우를 거의 제거하기 때문에! 일반적인 bfs와 시간복잡도가 비슷해지는 것임