### PR TITLE
dayeon-72414

### DIFF
--- a/programmers/41주차/72414/장다연.java
+++ b/programmers/41주차/72414/장다연.java
@@ -1,0 +1,58 @@
+import java.util.*;
+class Solution {
+    public String solution(String play_time, String adv_time, String[] logs) {
+        int playSec = timeToSec(play_time.split(":"));
+        int advSec = timeToSec(adv_time.split(":"));
+        
+        long[] total = new long[playSec+1];
+        
+        int[][] logsConverted = new int[logs.length][2];
+        for(int i=0; i<logs.length; i++){
+            int[] sec = logToSec(logs[i]);
+            //초 : 0 1 2 3 4 5
+            //값 : 0 +1 -1 0 0 0
+            total[sec[0]] += 1;
+            total[sec[1]] -= 1;
+        }
+        
+        for(int i=1; i<=playSec; i++){
+            //초 : 0 1 2 3 4 5
+            //값 : 0 1 1 0 0 0
+            total[i] += total[i-1];
+        }
+        
+        for(int i=1; i<=playSec; i++){
+            //초 : 0 1 2 3 4 5
+            //값 : 0 1 2 2 2 2 
+            total[i] += total[i-1];
+        }
+        
+        long max = total[advSec-1];
+        int answer = 0;
+        for(int i= advSec; i <= playSec; i++){
+            long now = total[i] - total[i-advSec];
+            if(now > max){
+                max = now;
+                answer = i - advSec + 1;
+            }
+        }
+        
+        return secToTime(answer);
+    }
+    private String secToTime(int sec){
+        int h = sec / 3600;
+        int m = (sec % 3600) / 60;
+        int s = (sec % 3600) % 60;
+        return (h<10?"0":"")+h+":"+(m<10?"0":"")+m+":"+(s<10?"0":"")+s;
+    }
+    private int[] logToSec(String log){
+        String[] logSplited = log.split("[:-]");
+        int[] rtn = new int[2];
+        rtn[0] = timeToSec(new String[]{logSplited[0],logSplited[1],logSplited[2]});
+        rtn[1] = timeToSec(new String[]{logSplited[3],logSplited[4],logSplited[5]});
+        return rtn;
+    }
+    private int timeToSec(String[] time){
+        return Integer.parseInt(time[0])*3600+Integer.parseInt(time[1])*60+Integer.parseInt(time[2]);
+    }
+}


### PR DESCRIPTION
## 🍪 문제 번호
#554

## 🍊 문제 정의
#### input
"죠르디"의 동영상 재생시간 길이 play_time, 공익광고의 재생시간 길이 adv_time, 시청자들이 해당 동영상을 재생했던 구간 정보 logs
#### output
시청자들의 누적 재생시간이 가장 많이 나오는 곳에 공익광고를 삽입하려고 합니다. 이때, 공익광고가 들어갈 시작 시각

## 🍑 알고리즘 설계
처음에는 유격 시스템 문제처럼, 종료시각을 기준으로 정렬하고 시작시간을 비교하면서 공익광고가 들어갈 시간을 구하려고 했으나 이렇게 풀면 '모든 시각에 대해 광고를 틀었을 때의 누적 시청자 수'를 계산해야 하기 때문에 <b>누적 합</b> 방식이 가장 직관적이고 효율적이라는 지피티의 말씀이 있었다..!

그래서 누적합. 옛날에 '파괴되지 않는 건물' https://howudong.tistory.com/418 이 문제처럼 누적합을 이용해서 풀어야했던 것!

1. 먼저 각 초마다 사람이 몇명 듣는지 누적합을 하기 위해 시작 시점에는 +1, 끝나는 시점에는 -1을 해줘 누적합을 해주고,
2. 다시 한 번 각 초마다 현재값 += 이전값을 해줘 '모든 시각에 대해 광고를 틀었을 때의 누적 시청자 수'를 total의 각 인덱스 즉 각 초마다 저장해준다.
3. max값을 구하고 그 시간을 리턴한다!

## 🥝 최악 수행 시간 복잡도
O(n)

## 🍰 특이 사항 (Optional)
gpt랑 같이 품
